### PR TITLE
Fix failing Travis-CI due to pip packages not supporting Python 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,7 +187,8 @@ RUN cd /tmp && \
 
 # Install additional plugins
 RUN cd /opt && \
-    wget -O get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+    #wget -O get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+    wget -O get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
     python2 get-pip.py && \
     pip install "pymssql<3.0" && \
     pip3 install pywbem && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 LABEL maintainer="Tronyx <tronyx@tronflix.app>"
 
 # Environment variables
+# Environment variables
 ENV NAGIOS_HOME=/opt/nagios \
     NAGIOS_USER=nagios \
     NAGIOS_GROUP=nagios \
@@ -15,14 +16,15 @@ ENV NAGIOS_HOME=/opt/nagios \
     APACHE_RUN_GROUP=nagios \
     NAGIOS_TIMEZONE=UTC \
     DEBIAN_FRONTEND=noninteractive \
-    NG_NAGIOS_CONFIG_FILE=${NAGIOS_HOME}/etc/nagios.cfg \
-    NG_CGI_DIR=${NAGIOS_HOME}/sbin \
-    NG_WWW_DIR=${NAGIOS_HOME}/share/nagiosgraph \
     NG_CGI_URL=/cgi-bin \
     NAGIOS_BRANCH=nagios-4.4.6 \
     NAGIOS_PLUGINS_BRANCH=release-2.3.3 \
     NRPE_BRANCH=nrpe-4.0.2 \
     NSCA_TAG=nsca-2.10.0
+
+ENV NG_NAGIOS_CONFIG_FILE=${NAGIOS_HOME}/etc/nagios.cfg \
+    NG_CGI_DIR=${NAGIOS_HOME}/sbin \
+    NG_WWW_DIR=${NAGIOS_HOME}/share/nagiosgraph
 
 RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections && \
     echo postfix postfix/mynetworks string "127.0.0.0/8" | debconf-set-selections && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -190,8 +190,7 @@ RUN cd /opt && \
     #wget -O get-pip.py https://bootstrap.pypa.io/get-pip.py && \
     wget -O get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
     python2 get-pip.py && \
-    pip install "pymssql<3.0" && \
-    pip3 install pywbem && \
+    pip install "pymssql<2.2.0" pywbem && \
     git clone https://github.com/willixix/naglio-plugins.git WL-Nagios-Plugins && \
     git clone https://github.com/JasonRivers/nagios-plugins.git JR-Nagios-Plugins && \
     git clone https://github.com/justintime/nagios-plugins.git JE-Nagios-Plugins && \


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
*Please fill in any appropriate check-boxes, e.g: [X]*

-   [X]   I have read and understood the [contributors guide](https://github.com/christronyxyocum/tronitor/blob/master/.github/CONTRIBUTING.md), as well as this entire template.
-   [X]   I have made only one major change in my proposed changes.
-   [X]   I have commented my proposed changes within the code.
-   [X]   I have tested my proposed changes, and have included unit tests where possible.
-   [X]   I am willing to help maintain this change if there are issues with it later.
-   [X]   I give this submission freely and claim no ownership.

---
**What does this PR aim to accomplish?:**
I started this PR in order to solve #4 and #3. I figured out that in the meantime you solved it with 2b512360953638345d95a579c6ed9335938d9303 but Travis is failing so I made the changes to fix Travis.

**How does this PR accomplish the above?:**
Update pymssql version, since from version 2.2.0 onwards it is not compatible anymore with Pyhton 2.7.
I also took the opportunity to install pywbem with pip2 iso pip3 since the latest version supports both. @tronyx let me know if this is on purpose that you install with pip3 and I should not modify it (since I do not use this library in my configuration I could not say if it has any impact)
I have generated new image and run it successfully with my Nagios config (confirmed fixed #3 and  #4)

**What documentation changes (if any) are needed to support this PR?:**
None AFAIK

---
-   You must follow the template instructions. Failure to do so will result in your pull request being closed.
-   Please respect that Tronitor is developed by volunteers, IE: me, who can only reply in their spare time.
