### PR TITLE
Add GitHub actions to build for all plattforms with buildx

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile
+      - uses: actions/checkout@v2
+        name: Checkout
+        
+      
+      - uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      - name: Build
+        run: |
+          docker build . # will run buildx

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           install: true
 
-      - name: Build
+      - name: Build 
         run: |
-          docker build . # will run buildx
+          docker build --platform ${{ steps.buildx.outputs.platforms }} . # will run buildx

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           install: true
 
-      - name: Build x86
-        run: |
-          docker buildx build --platform linux/386 .
+      #- name: Build x86
+      #  run: |
+      #    docker buildx build --platform linux/386 .
 
       - name: Build amd64
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout
-        
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1        
-      
+        uses: docker/setup-qemu-action@v1
+
       - uses: docker/setup-buildx-action@v1
         id: buildx
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,9 +44,4 @@ jobs:
       - name: Build riscv64
         run: |
           docker buildx build --platform linux/riscv64 .
-      
-      - name: Build every remaining arch
-        # This wont rebuild the privious images because of the build cache
-        run: |
-          docker buildx build --platform ${{ steps.buildx.outputs.platforms }} .
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,11 +16,14 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout
         
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1        
       
       - uses: docker/setup-buildx-action@v1
         id: buildx
         with:
           install: true
+
       - name: Build
         run: |
           docker build . # will run buildx

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,6 +24,27 @@ jobs:
         with:
           install: true
 
-      - name: Build 
+      - name: Build x86
         run: |
-          docker build --platform ${{ steps.buildx.outputs.platforms }} . # will run buildx
+          docker buildx build --platform linux/386 .
+
+      - name: Build amd64
+        run: |
+          docker buildx build --platform linux/amd64 .
+
+      - name: Build arm64
+        run: |
+          docker buildx build --platform linux/arm64 .
+
+      - name: Build armv7
+        run: |
+          docker buildx build --platform linux/arm/v7 .
+
+      - name: Build riscv64
+        run: |
+          docker buildx build --platform linux/riscv64 .
+      
+      - name: Build every remaining arch
+        # This wont rebuild the privious images because of the build cache
+        run: |
+          docker buildx build --platform ${{ steps.buildx.outputs.platforms }} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,7 @@ RUN update-ca-certificates -f
 RUN cd /tmp && \
     git clone https://github.com/NagiosEnterprises/nagioscore.git -b ${NAGIOS_BRANCH} && \
     cd nagioscore && \
+    cp /usr/share/misc/config.* . && \
     ./configure \
         --prefix=${NAGIOS_HOME} \
         --exec-prefix=${NAGIOS_HOME} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,9 +161,7 @@ RUN wget -q -O ${NAGIOS_HOME}/libexec/check_ncpa.py https://raw.githubuserconten
 RUN cd /tmp && \
     git clone https://github.com/NagiosEnterprises/nrpe.git -b ${NRPE_BRANCH} && \
     cd nrpe && \
-    ./configure \
-        --with-ssl=/usr/bin/openssl \
-        --with-ssl-lib=/usr/lib/$(uname -m)-linux-gnu && \
+    ./configure && \
     make check_nrpe > /dev/null && \
     cp src/check_nrpe ${NAGIOS_HOME}/libexec/ && \
     make clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,8 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         libnet-tftp-perl \
         libnet-xmpp-perl \
         libpq-dev \
+        libpython2-dev \
+        libpython3-dev \
         libredis-perl \
         librrds-perl \
         libssl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         bc \
         bsd-mailx \
         build-essential \
+        ca-certificates \
         dnsutils \
         fping \
         freetds-dev \
@@ -115,6 +116,8 @@ RUN ( grep -Ei "^${NAGIOS_GROUP}"    /etc/group || groupadd $NAGIOS_GROUP ) && \
     ( grep -Ei "^${NAGIOS_CMDGROUP}" /etc/group || groupadd $NAGIOS_CMDGROUP )
 RUN ( id -u $NAGIOS_USER    || useradd --system -d $NAGIOS_HOME -g $NAGIOS_GROUP    $NAGIOS_USER ) && \
     ( id -u $NAGIOS_CMDUSER || useradd --system -d $NAGIOS_HOME -g $NAGIOS_CMDGROUP $NAGIOS_CMDUSER )
+
+RUN update-ca-certificates -f
 
 # Install Nagios Core
 RUN cd /tmp && \


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
*Please fill in any appropriate check-boxes, e.g: [X]*

-   [x]   I have read and understood the [contributors guide](https://github.com/christronyxyocum/tronitor/blob/master/.github/CONTRIBUTING.md), as well as this entire template.
-   [x]   I have made only one major change in my proposed changes.: -> I had to fix some additional things (see commits) to get it working.
-   [x]   I have commented my proposed changes within the code.
-   [x]   I have tested my proposed changes, and have included unit tests where possible. -> See Github Actions Checks
-   [x]   I am willing to help maintain this change if there are issues with it later. -> Just Tag me on any issue related to my changes ;-)
-   [x]   I give this submission freely and claim no ownership.
---
**What does this PR aim to accomplish?:**
This PR aims to introduce Github Actions in order to use buildx to build the image for multiple architectures.

**How does this PR accomplish the above?:**
Use Github Actions to checkout the repo, install qemu, install buldx and after that build the image for the different platforms

**What documentation changes (if any) are needed to support this PR?:**
I don't think much is needed here.

**Additional comments:**
First i haven't seen that the repo already uses TravisCI so i wanted to use Github Actions to build and upload with buildx for all architectures.
